### PR TITLE
handler with ”*” as path will match any path

### DIFF
--- a/lambdarest/__init__.py
+++ b/lambdarest/__init__.py
@@ -101,7 +101,7 @@ def create_lambda_handler():
         error_tuple = ("Internal server error", 500)
         logging_message = "[%s][{status_code}]: {message}" % method_name
         try:
-            func = http_methods[path][method_name]
+            func = http_methods.get(path, http_methods.get("*", {}))[method_name]
         except KeyError:
             logging.warning(logging_message.format(
                 status_code=405, message="Not supported"))

--- a/tests/test_lambdarest.py
+++ b/tests/test_lambdarest.py
@@ -6,6 +6,8 @@ except ImportError:
 import unittest
 import json
 import copy
+import random
+from datetime import datetime
 
 from lambdarest import create_lambda_handler
 
@@ -267,3 +269,26 @@ class TestLambdarestFunctions(unittest.TestCase):
             "body": '"bar"',
             "statusCode": 200,
             "headers": {}}
+
+    def test_that_no_path_specified_match_all(self):
+        random.seed(datetime.now().timestamp())
+
+        json_body = {}
+        self.event["body"] = json.dumps(json_body)
+        self.event["httpMethod"] = "PUT"
+
+        get_mock = mock.Mock(return_value="foo")
+
+        self.lambda_handler.handle("put", path="*")(get_mock)
+
+        r = range(1000)
+        for i in range(10):
+            # test with a non-deterministic path
+            self.event["path"] = "/foo/{}".format(random.choice(r))
+            print(self.event["path"])
+            result = self.lambda_handler(self.event, self.context)
+            assert result == {
+                "body": '"foo"',
+                "statusCode": 200,
+                "headers": {}
+            }

--- a/tests/test_lambdarest.py
+++ b/tests/test_lambdarest.py
@@ -285,7 +285,6 @@ class TestLambdarestFunctions(unittest.TestCase):
         for i in range(10):
             # test with a non-deterministic path
             self.event["path"] = "/foo/{}".format(random.choice(r))
-            print(self.event["path"])
             result = self.lambda_handler(self.event, self.context)
             assert result == {
                 "body": '"foo"',


### PR DESCRIPTION
Like discussed in #20, we needed a way to match all path.

With this PR, you can pass `"*"` as the `path` parameter, and the handler will match any path.

Any feedback would be appreciated! 