### PR TITLE
Return none and not empty string on empty body

### DIFF
--- a/lambdarest/__init__.py
+++ b/lambdarest/__init__.py
@@ -3,7 +3,7 @@
 
 __author__ = """sloev"""
 __email__ = 'jgv@trustpilot.com'
-__version__ = '2.2.6'
+__version__ = '3.0.0'
 
 
 import json

--- a/lambdarest/__init__.py
+++ b/lambdarest/__init__.py
@@ -30,7 +30,7 @@ class Response(object):
 
     def to_json(self):
         return {
-            "body": json.dumps(self.body or ""),
+            "body": json.dumps(self.body or None),
             "statusCode": self.status_code or 200,
             "headers": self.headers or {}
         }

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ extras = {
 
 setup(
     name='lambdarest',
-    version='2.2.6',
+    version='3.0.0',
     description="pico framework for aws lambda with optional json schema validation",
     long_description=readme + '\n\n' + history,
     author="jgv",


### PR DESCRIPTION
Some endpoints require us to return `200` but also require the body to be empty. The current default results in an otherwise empty body being set to `""` which is surprising and in our case a bit unfortunate.