### PR TITLE
Use workzeug for route parsing

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -44,3 +44,9 @@ First OSS release
 
 **features**
 - An error handler can now be passed when creating a handler. Any unhandled error will be re-raise when None is passed
+
+4.0.0 (2018-04-06)
++++++++++++++++++++
+
+**features**
+- added Werkzeug path parameters

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ def my_own_get(event, id):
 input_event = {
     "body": '{}',
     "httpMethod": "GET",
-    "path": "/foo/1234"
+    "path": "/foo/1234/"
 }
 result = lambda_handler(event=input_event)
 assert result == {"body": '{"my-id": 1234}', "statusCode": 200, "headers":{}}

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ my_schema = {
     }
 }
 
-@lambda_handler.handle("get", schema=my_schema)
+@lambda_handler.handle("get", path="/with-schema/", schema=my_schema)
 def my_own_get(event):
     return {"this": "will be json dumped"}
 
@@ -75,7 +75,7 @@ def my_own_get(event):
 valid_input_event = {
     "body": '{"foo":"bar"}',
     "httpMethod": "GET",
-    "path": "/"
+    "path": "/with-schema/"
 }
 result = lambda_handler(event=valid_input_event)
 assert result == {"body": '{"this": "will be json dumped"}', "statusCode": 200, "headers":{}}
@@ -84,7 +84,7 @@ assert result == {"body": '{"this": "will be json dumped"}', "statusCode": 200, 
 invalid_input_event = {
     "body": '{"foo":666}',
     "httpMethod": "GET",
-    "path": "/"
+    "path": "/with-schema/"
 }
 result = lambda_handler(event=invalid_input_event)
 assert result == {"body": '"Validation Error"', "statusCode": 400, "headers":{}}
@@ -116,7 +116,7 @@ my_schema = {
     }
 }
 
-@lambda_handler.handle("get", schema=my_schema)
+@lambda_handler.handle("get", path="/with-params/", schema=my_schema)
 def my_own_get(event):
     return event["json"]["query"]
 
@@ -129,7 +129,7 @@ valid_input_event = {
         "foo": "1, 2.2, 3"
     },
     "httpMethod": "GET",
-    "path": "/"
+    "path": "/with-params/"
 }
 result = lambda_handler(event=valid_input_event)
 assert result == {"body": '{"foo": [1.0, 2.2, 3.0]}', "statusCode": 200, "headers":{}}
@@ -164,7 +164,7 @@ And you can specify path parameters as well, which will be passed as keyword arg
 ```python
 from lambdarest import lambda_handler
 
-@lambda_handler.handle("get", path="/foo/<int:id>/<string:what>/")
+@lambda_handler.handle("get", path="/foo/<int:id>/")
 def my_own_get(event, id):
     return {"my-id": id}
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,29 @@ result = lambda_handler(event=input_event)
 assert result == {"body": '{"this": "will be json dumped"}', "statusCode": 200, "headers":{}}
 ```
 
+And you can specify path parameters as well, which will be passed as keyword arguments:
+
+```python
+from lambdarest import lambda_handler
+
+@lambda_handler.handle("get", path="/foo/<int:id>/<string:what>/")
+def my_own_get(event, id):
+    return {"my-id": id}
+
+
+##### TEST #####
+
+
+input_event = {
+    "body": '{}',
+    "httpMethod": "GET",
+    "path": "/foo/1234"
+}
+result = lambda_handler(event=input_event)
+assert result == {"body": '{"my-id": 1234}', "statusCode": 200, "headers":{}}
+```
+
+
 ## Anormal unittest behaviour with `lambda_handler` singleton
 
 Because of python unittests leaky test-cases it seems like you shall beware of [this issue](https://github.com/trustpilot/python-lambdarest/issues/16) when using the singleton `lambda_handler` in a multiple test-case scenario.

--- a/lambdarest/__init__.py
+++ b/lambdarest/__init__.py
@@ -39,7 +39,7 @@ class Response(object):
 def __float_cast(value):
     try:
         return float(value)
-    except:
+    except Exception:
         pass
     return value
 
@@ -47,7 +47,7 @@ def __float_cast(value):
 def __marshall_query_params(value):
     try:
         value = json.loads(value)
-    except:
+    except Exception:
         value_cand = value.split(",")
         if len(value_cand) > 1:
             value = list(map(__float_cast, value_cand))
@@ -58,7 +58,7 @@ def __json_load_query(query):
     query = query or {}
 
     return {key: __marshall_query_params(value)
-            for key,value in query.items()}
+            for key, value in query.items()}
 
 
 def default_error_handler(error, method):

--- a/lambdarest/__init__.py
+++ b/lambdarest/__init__.py
@@ -111,16 +111,13 @@ def create_lambda_handler(error_handler=default_error_handler):
         error_tuple = ("Internal server error", 500)
         logging_message = "[%s][{status_code}]: {message}" % method_name
         try:
-            mapping = url_maps.bind('example.com', '')
+            # bind the mapping to an empty server name
+            mapping = url_maps.bind('')
             func, kwargs = mapping.match(path, method=method_name)
         except NotFound as e:
             logging.warning(logging_message.format(
                 status_code=404, message=str(e)))
             error_tuple = (str(e), 404)
-        except KeyError:
-            logging.warning(logging_message.format(
-                status_code=405, message="Not supported"))
-            error_tuple = ("Not supported", 405)
 
         if func:
             try:
@@ -180,9 +177,7 @@ def create_lambda_handler(error_handler=default_error_handler):
                 return func(event, *args, **kwargs)
 
             # register http handler function
-            # url_maps.setdefault(path.lower(), {})[method_name.lower()] = inner
             rule = Rule(path, endpoint=inner, methods=[method_name.lower()])
-            print(rule)
             url_maps.add(rule)
             return inner
         return wrapper

--- a/lambdarest/__init__.py
+++ b/lambdarest/__init__.py
@@ -3,7 +3,7 @@
 
 __author__ = """sloev"""
 __email__ = 'jgv@trustpilot.com'
-__version__ = '3.0.1'
+__version__ = '4.0.0'
 
 
 import json

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ test_requirements = [
     'pytest==2.9.2',
     'mock>=2.0.0',
     'pytest-readme>=1.0.0',
+    'isort==4.2.15', # dependency of pylint
     'prospector>=0.12.5',
     'jsonschema>=2.5.1',
     'strict_rfc3339>=0.7'

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ with open('HISTORY.rst') as history_file:
 requirements = [
     'jsonschema>=2.5.1',
     'strict_rfc3339>=0.7',
+    'werkzeug>=0.14.1'
 ]
 
 test_requirements = [

--- a/tests/test_lambdarest.py
+++ b/tests/test_lambdarest.py
@@ -285,7 +285,7 @@ class TestLambdarestFunctions(unittest.TestCase):
         r = range(1000)
         for i in range(10):
             # test with a non-deterministic path
-            self.event["path"] = "/foo/{}".format(random.choice(r))
+            self.event["path"] = "/foo/{}/".format(random.choice(r))
             result = self.lambda_handler(self.event, self.context)
             assert result == {
                 "body": '"foo"',


### PR DESCRIPTION
TL/DR: This PR makes paths like `/foo/bar/<int:id>/` work.

I needed path parameter support for my api, I noticed that Workzeug (from Flask) solved that issue already, and here we are.

- I added a dependency on workzeug
- I added the mapper for mapping the function calls
- I added a short description in the readme