### PR TITLE
Fix path casing

### DIFF
--- a/lambdarest/__init__.py
+++ b/lambdarest/__init__.py
@@ -104,7 +104,7 @@ def create_lambda_handler(error_handler=default_error_handler):
 
         # Save context within event for easy access
         event["context"] = context
-        path = event['resource'].lower()
+        path = event['resource']
 
         # proxy is a bit weird. We just replace the value in the uri with the
         # actual value provided by apigw, and use that

--- a/lambdarest/__init__.py
+++ b/lambdarest/__init__.py
@@ -3,7 +3,7 @@
 
 __author__ = """sloev"""
 __email__ = 'jgv@trustpilot.com'
-__version__ = '4.1.1'
+__version__ = '4.1.2'
 
 
 import json

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ extras = {
 
 setup(
     name='lambdarest',
-    version='4.1.1',
+    version='4.1.2',
     description="pico framework for aws lambda with optional json schema validation",
     long_description=readme + '\n\n' + history,
     author="jgv",

--- a/tests/test_lambdarest.py
+++ b/tests/test_lambdarest.py
@@ -289,6 +289,31 @@ class TestLambdarestFunctions(unittest.TestCase):
             "statusCode": 200,
             "headers": {}}
 
+    def test_that_uppercase_works(self):
+        json_body = {}
+
+        self.event["body"] = json.dumps(json_body)
+        self.event["httpMethod"] = "GET"
+
+        def test_wordcase(request, foo):
+            return foo
+
+        self.lambda_handler.handle("get", path="/foo/bar/<string:foo>")(test_wordcase)  # decorate mock
+
+        self.event["resource"] = "/foo/bar/foobar"
+        result1 = self.lambda_handler(self.event, self.context)
+        assert result1 == {
+            "body": '"foobar"',
+            "statusCode": 200,
+            "headers": {}}
+
+        self.event["resource"] = "/foo/bar/FOOBAR"
+        result2 = self.lambda_handler(self.event, self.context)
+        assert result2 == {
+            "body": '"FOOBAR"',
+            "statusCode": 200,
+            "headers": {}}
+
 
     def test_that_apigw_with_proxy_param_works(self):
         json_body = {}


### PR DESCRIPTION
I found a bug with upper an downcases when using variables.

Given the path `/foo/<string:foo>`, `/foo/BAR` would not match, while `/foo/bar` would.  This PR fixes that issue.