### PR TITLE
Fixed issue where using path parameters but no custom domain broke

### DIFF
--- a/lambdarest/__init__.py
+++ b/lambdarest/__init__.py
@@ -104,7 +104,15 @@ def create_lambda_handler(error_handler=default_error_handler):
 
         # Save context within event for easy access
         event["context"] = context
-        path = event['resource']
+
+        # check if resource and path are the same. If so, use the requested
+        # resource path, which will contain the actual requested pathself.
+        # If they are not the same, this is probably a proxied or custom domain
+        # where we need to use the event resource
+        if 'path' in event and event['resource'][0:3] == event['path'][0:3]:
+            path = event['path']
+        else:
+            path = event['resource']
 
         # proxy is a bit weird. We just replace the value in the uri with the
         # actual value provided by apigw, and use that

--- a/lambdarest/__init__.py
+++ b/lambdarest/__init__.py
@@ -106,9 +106,9 @@ def create_lambda_handler(error_handler=default_error_handler):
         event["context"] = context
 
         # check if resource and path are the same. If so, use the requested
-        # resource path, which will contain the actual requested pathself.
-        # If they are not the same, this is probably a proxied or custom domain
-        # where we need to use the event resource
+        # resource path, which will contain the actual requested path itself.
+        # If they are not the same, this is a proxied or custom domain where
+        # we need to use the event resource
         if 'path' in event and event['resource'][0:3] == event['path'][0:3]:
             path = event['path']
         else:


### PR DESCRIPTION
I just redeployed an api to api gateway without a custom domain, but with path parameters in the url. This broke the parsing. I think this was an edge cased that I missed last time.

This change fixes this issue. It checks if both `path` and `resource` are set. If so, it checks if they are the same. If so, it uses `resource`, if not. It uses `path`, which will contain all the values for the path parameters.