### PR TITLE
Support of resource path {placeholders} in the middle

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,31 @@ result = lambda_handler(event=input_event)
 assert result == {"body": '{"my-id": 1234}', "statusCode": 200, "headers":{}}
 ```
 
+Or you can specify more complex parametrized resource path and get parameteres as arguments:
+```python
+from lambdarest import lambda_handler
+
+@lambda_handler.handle("get", path="/object/<int:object_id>/props/<string:foo>/get")
+def my_own_get(event, object_id, foo):
+    return {"object_id": int(object_id), "foo": foo}
+
+
+##### TEST #####
+
+input_event = {
+    "body": '{}',
+    "httpMethod": "GET",
+    "path": "/v1/object/777/props/bar/get",
+    "resource": "/object/{object_id}/props/{foo}/get",
+    "pathParameters": {
+      "object_id": "777",
+      "foo":"bar"
+    }
+}
+result = lambda_handler(event=input_event)
+assert result == {"body": '{"object_id": 777, "foo": "bar"}', "statusCode": 200, "headers":{}}
+
+```
 Or use the Proxy APIGateway magic endpoint:
 ```python
 from lambdarest import lambda_handler

--- a/lambdarest/__init__.py
+++ b/lambdarest/__init__.py
@@ -102,10 +102,8 @@ def check_update_and_fill_resource_placeholders(resource, path_parameters):
     # to /foo/${key1}/bar/${key2}/{proxy+}
     for path_key in (path_parameters):
         resource = resource.replace(
-            f'{{{path_key}}}', f'${{{path_key}}}'
+            '{%s}' % path_key, '${%s}' % path_key
         )
-
-    print(resource)
 
     # insert path_parameteres by template
     # /foo/${key1}/bar/${key2}/{proxy+} -> /foo/value1/bar/value2/{proxy+}

--- a/lambdarest/__init__.py
+++ b/lambdarest/__init__.py
@@ -100,12 +100,13 @@ def check_update_and_fill_resource_placeholders(resource, path_parameters):
     # prepare resource.
     # evaluate from /foo/{key1}/bar/{key2}/{proxy+}
     # to /foo/${key1}/bar/${key2}/{proxy+}
-    try:
+
+    if path_parameters is not None:
         for path_key in (path_parameters):
             resource = resource.replace(
                 '{%s}' % path_key, '${%s}' % path_key
             )
-    except Exception:
+    else:
         return base_resource
 
     # insert path_parameteres by template
@@ -159,9 +160,11 @@ def create_lambda_handler(error_handler=default_error_handler, json_encoder=json
             resource = event['resource']
 
         # Fill placeholders in resource path
-        resource = check_update_and_fill_resource_placeholders(
-            resource, event['pathParameters']
-        )
+        if 'pathParameters' in event:
+            resource = check_update_and_fill_resource_placeholders(
+                resource, event['pathParameters']
+            )
+
         path = resource
 
         # Check if a path is set, if so, check if the base path is the same as

--- a/lambdarest/__init__.py
+++ b/lambdarest/__init__.py
@@ -100,10 +100,13 @@ def check_update_and_fill_resource_placeholders(resource, path_parameters):
     # prepare resource.
     # evaluate from /foo/{key1}/bar/{key2}/{proxy+}
     # to /foo/${key1}/bar/${key2}/{proxy+}
-    for path_key in (path_parameters):
-        resource = resource.replace(
-            '{%s}' % path_key, '${%s}' % path_key
-        )
+    try:
+        for path_key in (path_parameters):
+            resource = resource.replace(
+                '{%s}' % path_key, '${%s}' % path_key
+            )
+    except Exception:
+        return base_resource
 
     # insert path_parameteres by template
     # /foo/${key1}/bar/${key2}/{proxy+} -> /foo/value1/bar/value2/{proxy+}

--- a/lambdarest/__init__.py
+++ b/lambdarest/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 import logging
+from string import Template
 from jsonschema import validate, ValidationError, FormatChecker
 from werkzeug.routing import Map, Rule, NotFound
 from werkzeug.http import HTTP_STATUS_CODES
@@ -82,6 +83,39 @@ def default_error_handler(error, method):
         message=str(error)
     ))
 
+def check_update_and_fill_resource_placeholders(resource, path_parameters):
+    """
+    Prepare resource parameters before routing.
+    In case when resource defined as /path/to/{placeholder}/resource,
+    the router can't find a correct handler.
+    This method inserts path parameters
+    instead of placeholders and returns the result.
+
+    :param resource: Resource path definition
+    :param path_parameters: Path parameters dict
+    :return: resource definition with inserted path parameters
+    """
+    base_resource = resource
+
+    # prepare resource.
+    # evaluate from /foo/{key1}/bar/{key2}/{proxy+}
+    # to /foo/${key1}/bar/${key2}/{proxy+}
+    for path_key in (path_parameters):
+        resource = resource.replace(
+            f'{{{path_key}}}', f'${{{path_key}}}'
+        )
+
+    print(resource)
+
+    # insert path_parameteres by template
+    # /foo/${key1}/bar/${key2}/{proxy+} -> /foo/value1/bar/value2/{proxy+}
+    template = Template(resource)
+    try:
+        resource = template.substitute(**(path_parameters))
+        return resource
+    except KeyError:
+        return base_resource
+
 
 def create_lambda_handler(error_handler=default_error_handler, json_encoder=json.JSONEncoder, application_load_balancer=False):
     """Create a lambda handler function with `handle` decorator as attribute
@@ -122,6 +156,11 @@ def create_lambda_handler(error_handler=default_error_handler, json_encoder=json
             resource = event['path']
         else:
             resource = event['resource']
+
+        # Fill placeholders in resource path
+        resource = check_update_and_fill_resource_placeholders(
+            resource, event['pathParameters']
+        )
         path = resource
 
         # Check if a path is set, if so, check if the base path is the same as


### PR DESCRIPTION
I made a resource path preparing before routing.

The issue was found when I tried to implement lambda for working with URL /bay/{bay_id}/status.
The router was not able to find a correct handler.

I made preparing of the path before routing. Now, the resource path is being filled by path parameters before the routing, but if the parameters list is incorrect, the code still returns code 404.