### PR TITLE
Support of resource path {placeholders} in the middle

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ assert result == {"body": '{"my-id": 1234}', "statusCode": 200, "headers":{}}
 
 Or you can specify more complex parametrized resource path and get parameteres as arguments:
 ```python
-from .lambdarest import lambda_handler
+from lambdarest import lambda_handler
 
 @lambda_handler.handle("get", path="/object/<int:object_id>/props/<string:foo>/get")
 def my_own_get(event, object_id, foo):

--- a/README.md
+++ b/README.md
@@ -183,11 +183,11 @@ assert result == {"body": '{"my-id": 1234}', "statusCode": 200, "headers":{}}
 
 Or you can specify more complex parametrized resource path and get parameteres as arguments:
 ```python
-from lambdarest import lambda_handler
+from .lambdarest import lambda_handler
 
 @lambda_handler.handle("get", path="/object/<int:object_id>/props/<string:foo>/get")
 def my_own_get(event, object_id, foo):
-    return {"object_id": int(object_id), "foo": foo}
+    return [{"object_id": int(object_id)}, {"foo": foo}]
 
 
 ##### TEST #####
@@ -203,7 +203,7 @@ input_event = {
     }
 }
 result = lambda_handler(event=input_event)
-assert result == {"body": '{"object_id": 777, "foo": "bar"}', "statusCode": 200, "headers":{}}
+assert result == {"body": '[{"object_id": 777}, {"foo": "bar"}]', "statusCode": 200, "headers":{}}
 
 ```
 Or use the Proxy APIGateway magic endpoint:

--- a/lambdarest/__init__.py
+++ b/lambdarest/__init__.py
@@ -102,10 +102,8 @@ def check_update_and_fill_resource_placeholders(resource, path_parameters):
     # to /foo/${key1}/bar/${key2}/{proxy+}
     for path_key in (path_parameters):
         resource = resource.replace(
-            f'{{{path_key}}}', f'${{{path_key}}}'
+            '{%s}' % path_key, '${%s}' % path_key
         )
-
-    print(resource)
 
     # insert path_parameteres by template
     # /foo/${key1}/bar/${key2}/{proxy+} -> /foo/value1/bar/value2/{proxy+}

--- a/lambdarest/__init__.py
+++ b/lambdarest/__init__.py
@@ -100,12 +100,13 @@ def check_update_and_fill_resource_placeholders(resource, path_parameters):
     # prepare resource.
     # evaluate from /foo/{key1}/bar/{key2}/{proxy+}
     # to /foo/${key1}/bar/${key2}/{proxy+}
-    try:
+
+    if path_parameters is not None:
         for path_key in (path_parameters):
             resource = resource.replace(
                 '{%s}' % path_key, '${%s}' % path_key
             )
-    except Exception:
+    else:
         return base_resource
 
     # insert path_parameteres by template
@@ -159,9 +160,11 @@ def create_lambda_handler(error_handler=default_error_handler, json_encoder=json
             resource = event['resource']
 
         # Fill placeholders in resource path
-        resource = check_update_and_fill_resource_placeholders(
-            resource, event['pathParameters']
-        )
+        if 'pathParameters' in event:
+            resource = check_update_and_fill_resource_placeholders(
+                resource, event['pathParameters']
+            )
+
         path = resource
 
         # Check if a path is set, if so, check if the base path is the same as

--- a/lambdarest/__init__.py
+++ b/lambdarest/__init__.py
@@ -100,10 +100,13 @@ def check_update_and_fill_resource_placeholders(resource, path_parameters):
     # prepare resource.
     # evaluate from /foo/{key1}/bar/{key2}/{proxy+}
     # to /foo/${key1}/bar/${key2}/{proxy+}
-    for path_key in (path_parameters):
-        resource = resource.replace(
-            '{%s}' % path_key, '${%s}' % path_key
-        )
+    try:
+        for path_key in (path_parameters):
+            resource = resource.replace(
+                '{%s}' % path_key, '${%s}' % path_key
+            )
+    except Exception:
+        return base_resource
 
     # insert path_parameteres by template
     # /foo/${key1}/bar/${key2}/{proxy+} -> /foo/value1/bar/value2/{proxy+}

--- a/tests/test_lambdarest.py
+++ b/tests/test_lambdarest.py
@@ -438,5 +438,3 @@ class TestLambdarestFunctions(unittest.TestCase):
         result = self.lambda_handler(event=input_event)
 
         assert result['statusCode'] == 404
-
-

--- a/tests/test_lambdarest.py
+++ b/tests/test_lambdarest.py
@@ -398,3 +398,45 @@ class TestLambdarestFunctions(unittest.TestCase):
             "headers": {},
             "statusDescription": "HTTP OK",
             "isBase64Encoded": False})
+
+    def test_placeholder_filling(self):
+        def my_own_get(_, object_id, foo):
+            return [{"object_id": int(object_id)}, {"foo": foo}]
+
+        self.lambda_handler.handle("get", path="/object/<int:object_id>/props/<string:foo>/get")(my_own_get)
+        ##### TEST #####
+
+        input_event = {
+            "body": '{}',
+            "httpMethod": "GET",
+            "path": "/v1/object/777/props/bar/get",
+            "resource": "/object/{object_id}/props/{foo}/get",
+            "pathParameters": {
+                "object_id": "777",
+                "foo": "bar"
+            }
+        }
+        result = self.lambda_handler(event=input_event)
+        assert result == {"body": '[{"object_id": 777}, {"foo": "bar"}]', "statusCode": 200, "headers": {}}
+
+    def test_incomplete_placeholder_filling(self):
+        def my_own_get_1(_, object_id, foo):
+            return [{"object_id": int(object_id)}, {"foo": foo}]
+
+        self.lambda_handler.handle("get", path="/incomplete_object/<int:object_id>/props/<string:foo>/get")(my_own_get_1)
+        ##### TEST #####
+
+        input_event = {
+            "body": '{}',
+            "httpMethod": "GET",
+            "path": "/v1/object/777/props/bar/get",
+            "resource": "/object/{object_id}/props/{foo}/get",
+            "pathParameters": {
+                "object_id": "777"
+            }
+        }
+        result = self.lambda_handler(event=input_event)
+
+        assert result['statusCode'] == 404
+
+


### PR DESCRIPTION
I made a resource path preparing before routing.

The issue was found when I tried to implement lambda for working with URL /bay/{bay_id}/status.
The router was not able to find a correct handler.

I made preparing of the path before routing. Now, the resource path is being filled by path parameters before the routing, but if the parameters list is incorrect, the code still returns code 404.