### PR TITLE
Fixed issue with schema validation for schemas with oneOf element

### DIFF
--- a/lambdarest/__init__.py
+++ b/lambdarest/__init__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
 import logging
-import sys
 from string import Template
 from jsonschema import validate, ValidationError, FormatChecker
 from werkzeug.routing import Map, Rule, NotFound
@@ -258,7 +257,7 @@ def create_lambda_handler(
 
             except ValidationError as error:
                 error_description = "Schema[{}] with value {}".format(
-                    "][".join(error.absolute_schema_path), error.message
+                    "][".join(str(error.absolute_schema_path)), error.message
                 )
                 logging.warning(
                     logging_message.format(status_code=400, message=error_description)


### PR DESCRIPTION
The provided test case was failing without the fix. Code in line 261 of __init__.py was expecting all parts of error.absolute_schema_path to be strings but this is not the case if oneOf element in JSON schema is used.