### PR TITLE
Fixed issue with empty dict being returned as is instead of being converted to string

### DIFF
--- a/lambdarest/__init__.py
+++ b/lambdarest/__init__.py
@@ -37,7 +37,7 @@ class Response(object):
         """
         status_code = self.status_code or 200
         # if it's already a str, we don't need json.dumps
-        do_json_dumps = self.body and not isinstance(self.body, str)
+        do_json_dumps = self.body is not None and not isinstance(self.body, str)
         response = {
             "body": json.dumps(self.body, cls=encoder, sort_keys=True)
             if do_json_dumps

--- a/tests/test_lambdarest.py
+++ b/tests/test_lambdarest.py
@@ -215,6 +215,12 @@ class TestLambdarestFunctions(unittest.TestCase):
         result = self.lambda_handler(self.event, self.context)
         self.assertEqual(result, {"body": "foo", "headers": {}, "statusCode": 200})
 
+    def test_that_it_works_with_empty_dict_and_status_code_as_response(self):
+        post_mock = mock.Mock(return_value=({}, 200))
+        self.lambda_handler.handle("post")(post_mock)  # decorate mock
+        result = self.lambda_handler(self.event, self.context)
+        self.assertEqual(result, {"body": "{}", "headers": {}, "statusCode": 200})
+
     def test_that_specified_path_works(self):
         json_body = {}
 


### PR DESCRIPTION
Empty dict was not converted to string, instead it was returned as dict object. Included test case was failing before the proposed fix.