### PR TITLE
Supporting multiValueHeaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,49 @@ result = lambda_handler(event=valid_input_event)
 assert result == {"body": '{"foo": [1.0, 2.2, 3.0]}', "statusCode": 200, "headers":{}}
 ```
 
+### Headers and MultiValueHeaders
+
+You can return headers as part of your response, there is two types of headers:
+
+* **headers**: a dictionary
+* **multiValueHeaders**: a dictionary with multiple values for each key
+
+You can populate the headers in the following ways:
+
+1. return tuple with *normal header*
+
+```python
+return {'some':'json'}, 200, {'header':'value'}
+```
+
+2. return tuple with *normal header* **and** *multiValueHeaders*
+
+```json
+return {'some':'json'}, 200, {'header':'value'}, {'multi_header': ["foo", "bar"]}
+```
+
+3. return tuple with *multiValueHeaders*
+
+*(you need to still populate the headers as an empty dict)*
+
+```json
+return {'some':'json'}, 200, {}, {'multi_header': ["foo", "bar"]}
+```
+
+4. return [`Response`](https://github.com/trustpilot/python-lambdarest/blob/cd50bb4e1da4f720ef94534ccfd4989f398a9d5d/lambdarest/__init__.py#L17) object
+
+```python
+from lambdarest import Response
+# with headers
+Response({'some':'json'}, 200, headers={'header':'value'})
+
+# with multiValueHeaders
+Response({'some':'json'}, 200, multiValueHeaders={'multi_header': ["foo", "bar"]})
+
+# with headers and multiValueHeaders
+Response({'some':'json'}, 200, headers={'header':'value'}, multiValueHeaders={'multi_header': ["foo", "bar"]})
+```
+
 ### Routing
 
 You can also specify which path to react on for individual handlers using the `path` param:

--- a/tests/test_lambdarest.py
+++ b/tests/test_lambdarest.py
@@ -485,6 +485,25 @@ class TestLambdarestFunctions(unittest.TestCase):
             result, {"headers": {"Location": "https://example.com"}, "statusCode": 302}
         )
 
+    def test_that_standard_dict_responses_without_a_body_are_returned_as_is_multiHeader(
+        self,
+    ):
+        post_mock = mock.Mock(
+            return_value={
+                "statusCode": 302,
+                "multiValueHeaders": {"Location": ["https://example.com"]},
+            }
+        )
+        self.lambda_handler.handle("post")(post_mock)  # decorate mock
+        result = self.lambda_handler(self.event, self.context)
+        self.assertEqual(
+            result,
+            {
+                "multiValueHeaders": {"Location": ["https://example.com"]},
+                "statusCode": 302,
+            },
+        )
+
     def test_that_dict_responses_that_happen_to_have_a_body_key_retain_previous_behavior(
         self,
     ):


### PR DESCRIPTION
* This is to hopefully support multiValueHeaders in the response JSON for ALB.
* The code should only send one of `headers` or `multiValueHeaders`
* I added a test case verifying the new field, and all old code should work as before (test cases pass)
* Formatting was updated to match the `black` rules